### PR TITLE
fix dd-trace require order

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 'use strict';
+// this should the top level require, so DD could instrument the libraries
+if (process.env.DD_TRACE_ENABLED) global.tracer = require('dd-trace').init();
+
 const fs = require('fs');
 const async_hooks = require('async_hooks');
 const AWS = require('aws-sdk');
@@ -58,7 +61,6 @@ if (process.env.ASYNC_CONTEXT) {
     };
 })();
 
-if (process.env.DD_TRACE_ENABLED) global.tracer = require('dd-trace').init();
 if (process.env.LIGHTRUN_SECRET) {
     require('lightrun').start({
         lightrunSecret: process.env.LIGHTRUN_SECRET,


### PR DESCRIPTION
According to the docs dd-trace should be required before any libraries it can instrument.
By default all plugins are enabled, so AWS and pino can be instrumented by DD.

Since we set env variable DD_LOGS_INJECTION=true, DD will try to instrument pino

Example of the log before changes
```json
{"level":"INFO","time":1657275005951,"requestId":"cl5caqym60000edp1d7z38ari","message":"Request finished","url":"/payroll-events/","method":"GET","duration":"62 ms"}
```
vs after changes
```json
{"level":"INFO","time":1657275238009,"dd":{"trace_id":"7129507849806368343","span_id":"7675528490930169457","service":"employment","version":"0.0.0"},"requestId":"cl5cavxoi0000vqp18vov79y4","message":"Request finished","url":"/payroll-events/","method":"GET","duration":"52 ms"}
```